### PR TITLE
Schedule the win messages for the next tick

### DIFF
--- a/src/main/java/net/steelphoenix/chatgames/ChatGames.java
+++ b/src/main/java/net/steelphoenix/chatgames/ChatGames.java
@@ -43,7 +43,7 @@ import net.steelphoenix.core.util.Validate;
 
 public class ChatGames extends JavaPlugin implements ICGPlugin {
 	private final Set<UUID> exempt =  new HashSet<>();
-	private final ScriptEngineManager manager = new ScriptEngineManager();
+	private final ScriptEngineManager manager = new ScriptEngineManager(null);
 	private IConfig config;
 	private IGameTask task;
 	private IDatabase db;

--- a/src/main/java/net/steelphoenix/chatgames/listeners/ChatListener.java
+++ b/src/main/java/net/steelphoenix/chatgames/listeners/ChatListener.java
@@ -43,17 +43,21 @@ public class ChatListener implements Listener {
 		// Increment the player's score
 		plugin.getLeaderboard().increment(player.getUniqueId());
 
-		// Broadcast the win
-		((ChatGames) plugin).broadcast(Message.ANNOUNCEMENT_WIN.replace("%player%", player.getName()));
-		((ChatGames) plugin).broadcast(Message.ANNOUNCEMENT_TIME.replace("%time%", time));
+		// Schedule the messages for the next tick, so the player's chat message comes before the win broadcast
+        plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
 
-		// Event calling
-		AsyncChatGameWinEvent gameEvent = new AsyncChatGameWinEvent(game, player, message, answertime);
-		plugin.getServer().getPluginManager().callEvent(gameEvent);
+		    // Broadcast the win
+		    ((ChatGames) plugin).broadcast(Message.ANNOUNCEMENT_WIN.replace("%player%", player.getName()));
+		    ((ChatGames) plugin).broadcast(Message.ANNOUNCEMENT_TIME.replace("%time%", time));
 
-		// Send the winning player a message if defined
-		if (gameEvent.getWinMessage() != null) {
-			player.sendMessage(Util.color(gameEvent.getWinMessage()));
-		}
+		    // Event calling
+		    AsyncChatGameWinEvent gameEvent = new AsyncChatGameWinEvent(game, player, message, answertime);
+		    plugin.getServer().getPluginManager().callEvent(gameEvent);
+
+		    // Send the winning player a message if defined
+		    if (gameEvent.getWinMessage() != null) {
+		    	player.sendMessage(Util.color(gameEvent.getWinMessage()));
+		    }
+	    }, 1L);
 	}
 }


### PR DESCRIPTION
This schedules the win messages for the next tick, so the player's chat message comes before the win broadcast.

eg. Chat would read
```
<player> answer
Games >> player has won the game!
```
instead of this:
![image](https://user-images.githubusercontent.com/19366353/104123231-9fbb0b00-5395-11eb-9002-7277fe707f18.png)


Also I was missing a lot of things such as `net.steelphoenix.core.api.database.IDatabase` and wasn't able to compile my code, so you should probably test it before pulling.